### PR TITLE
Remove CSS alteration for datepicker

### DIFF
--- a/javascript/form.js
+++ b/javascript/form.js
@@ -152,10 +152,7 @@ $(document).ready(function () {
       firstDay: 1,
       autoSize:true,
       changeMonth:true,
-      changeYear:true,
-      beforeShow: function(input, inst) {
-          inst.dpDiv.css({marginTop: -input.offsetHeight + 'px', marginLeft: input.offsetWidth + 'px'});
-      }
+      changeYear:true
     }
   );
 

--- a/public/assets/v1/js/application.js
+++ b/public/assets/v1/js/application.js
@@ -1,4 +1,4 @@
-/*! opg-lpa-2 2015-08-03 */
+/*! opg-lpa-2 2015-08-12 */
 /*!
 
  handlebars v1.1.2
@@ -4878,10 +4878,7 @@ $(document).ready(function () {
       firstDay: 1,
       autoSize:true,
       changeMonth:true,
-      changeYear:true,
-      beforeShow: function(input, inst) {
-          inst.dpDiv.css({marginTop: -input.offsetHeight + 'px', marginLeft: input.offsetWidth + 'px'});
-      }
+      changeYear:true
     }
   );
 


### PR DESCRIPTION
I removed the line that was rewriting the position of the popup box - unfortunately it was repositioning the box after datepicker module had calculated where to put it. The original calculations take into account the viewport, but the repositioning shifted the box in relation to the input field without consideration for this.
