### PR TITLE
Add phone number to feedback form

### DIFF
--- a/module/Application/src/Application/Controller/General/FeedbackController.php
+++ b/module/Application/src/Application/Controller/General/FeedbackController.php
@@ -54,6 +54,7 @@ class FeedbackController extends AbstractBaseController
                     'rating' => $data['rating'],
                     'details' => $data['details'],
                     'email' => $data['email'],
+                    'phone' => $data['phone'],
                     'agent' => $_SERVER['HTTP_USER_AGENT'],
                     'fromPage' => $container->feedbackLinkClickedFromPage,
                 ]);

--- a/module/Application/src/Application/Form/General/FeedbackForm.php
+++ b/module/Application/src/Application/Form/General/FeedbackForm.php
@@ -57,6 +57,11 @@ class FeedbackForm extends AbstractForm {
             'type' => 'Email',
         ));
         
+        $this->add(array(
+            'name' => 'phone',
+            'type' => 'Text',
+        ));
+        
         //--------------------------------
 
         $inputFilter = $this->getInputFilter();
@@ -108,6 +113,14 @@ class FeedbackForm extends AbstractForm {
             ],
         ));
         
+        $inputFilter->add(array(
+            'name'     => 'phone',
+            'required' => false,
+            'filters'  => array(
+                array('name' => 'StripTags'),
+                array('name' => 'StringTrim'),
+            ),
+        ));
         $this->setInputFilter( $inputFilter );
 
     } // function

--- a/module/Application/view/application/feedback/index.twig
+++ b/module/Application/view/application/feedback/index.twig
@@ -17,6 +17,7 @@
 {% set type = form.get('rating') %}
 {% set details = form.get('details') %}
 {% set email = form.get('email') %}
+{% set phone = form.get('phone') %}
 
 {{ details.setAttributes({
     id: 'details',
@@ -30,6 +31,13 @@
     id: 'email',
     type: 'email',
     maxlength: 100,
+    class: 'form-control'
+}) ? ''}}
+
+{{ phone.setAttributes({
+    id: 'phone',
+    type: 'phone',
+    maxlength: 15,
     class: 'form-control'
 }) ? ''}}
 
@@ -72,7 +80,7 @@
     </fieldset>
 
     <div class="text">
-        <p>We are always working to improve this service. If you are happy to be contacted to give further feedback, please leave your email address.</p>
+        <p>We are always working to improve this service. If you are happy to be contacted to give further feedback, please leave your email address and/or phone number.</p>
     </div>
 
     <h2 class="heading-medium flush--top">Your email address (optional)</h2>
@@ -89,6 +97,20 @@
         </div>
     </fieldset>
 
+    <h2 class="heading-medium flush--top">Your phone number (optional)</h2>
+ 
+    <fieldset>
+        <legend class="group text">
+        </legend>
+        <div class="form-group {{ phone.getMessages|length >0 ? 'error'}}">
+            <label class="form-label text" for="{{ phone.getAttribute('id') }}">
+                <span class="visuallyhidden">Your phone number (optional)</span>
+                {{ formElementErrorsV2(phone) }}
+            </label>
+            {{ formElement(phone) }}
+        </div>
+    </fieldset>
+    
     <input type="submit" name="send" id="send" class="button" value="Send feedback">
 
 {{ form().closeTag|raw }}

--- a/module/Application/view/email/feedback.twig
+++ b/module/Application/view/email/feedback.twig
@@ -33,6 +33,15 @@
 </p>
 
 <p style="font-size: 19px; line-height: 1.315; margin: 0 0 20px 0; color: #0b0c0c">
+    <strong>Phone</strong><br>
+    {% if  phone|length > 0 %}
+        {{ phone }}
+    {% else %}
+        No phone number given
+    {% endif %}
+</p>
+
+<p style="font-size: 19px; line-height: 1.315; margin: 0 0 20px 0; color: #0b0c0c">
 	<strong>Feedback link clicked from</strong><br>
 	{{ fromPage }}
 </p>


### PR DESCRIPTION
@brettminnie Please could you cast a quick eye over this and then merge if ok to master - it just adds a phone number to the feedback form and then adds this field to the email template when sending to OPG.