### PR TITLE
BAU: Don't use tty.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ watch:
 
 .PHONY: test
 test:
-	docker run -it --rm -v $$(pwd):/app registry.service.opg.digital/opguk/phpunit module/Application/tests --bootstrap module/Application/tests/Bootstrap.php
+	docker run -i --rm -v $$(pwd):/app registry.service.opg.digital/opguk/phpunit module/Application/tests --bootstrap module/Application/tests/Bootstrap.php


### PR DESCRIPTION
Assigning interactive tty fails when running on jenkins. 