### PR TITLE
LPA-3147 Enable details polyfill for donor form

### DIFF
--- a/module/Application/view/application/authenticated/lpa/donor/form.twig
+++ b/module/Application/view/application/authenticated/lpa/donor/form.twig
@@ -293,6 +293,7 @@
 
     <script>
         GOVUK.performance.stageprompt.setupForGoogleAnalytics();
+        moj.Modules.DetailsPolyfill.init();
     </script>
 
 {% endblock %}


### PR DESCRIPTION
This is for IE11 when making an LPA based on another one, the
donor form detail polyfill won't initialise due to changing page
within the popup. This will enable it. Couldn't see any more
instances of this or I would have tried a more global fix.