### PR TITLE
Pin docker image to 0.0.318

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opg-php-fpm-71-ppa-1604
+FROM registry.service.opg.digital/opg-php-fpm-71-ppa-1604:0.0.318
 
 RUN groupadd webservice && \
     groupadd supervisor


### PR DESCRIPTION
Starfox needs to update the base images for the Sirius ECS migration. I've pinned all the refunds version to the latest version in master before our upgrade.